### PR TITLE
Connections Links

### DIFF
--- a/lib/my_john_deere_api/authorize.rb
+++ b/lib/my_john_deere_api/authorize.rb
@@ -13,6 +13,25 @@ module MyJohnDeereApi
     #
     # This is used to obtain authentication an access key/secret
     # on behalf of a user.
+    #
+    # parameters:
+    #
+    #     api_key - required JD API key for client application
+    #     api_secret - required JD API secret for client application
+    #     options - options hash, see below for details
+    #
+    # options:
+    #
+    #     :environment - one of [:live, :staging]
+    #     :scope - a space-delimited list of scopes requested
+    #     :scopes - an array of scopes requested. 'offline_access' will be added if
+    #               it isn't included already. This will overwrite :scope option if
+    #               both are provided.
+    #     :state -  a unique identifier for this request. JD will return this when
+    #               it redirects back after authorization, so that the client can identify
+    #               which of its users this request belongs to.
+    #     :redirect_uri - the uri for JD to redirect back to, after authorization.
+
 
     def initialize(api_key, api_secret, options = {})
       @options = DEFAULTS.merge(options)

--- a/lib/my_john_deere_api/model/base.rb
+++ b/lib/my_john_deere_api/model/base.rb
@@ -3,7 +3,7 @@ module MyJohnDeereApi
     include Helpers::CaseConversion
     include Helpers::UriHelpers
 
-    attr_reader :id, :record_type, :client, :links
+    attr_reader :id, :record, :record_type, :client, :links
 
     ##
     # arguments:
@@ -19,6 +19,7 @@ module MyJohnDeereApi
       verify_record_type(record['@type'])
 
       @id = record['id']
+      @record = record
       @record_type = record['@type']
       @client = client
       @unsaved = false

--- a/lib/my_john_deere_api/model/organization.rb
+++ b/lib/my_john_deere_api/model/organization.rb
@@ -28,6 +28,20 @@ module MyJohnDeereApi
       @assets = MyJohnDeereApi::Request::Collection::Assets.new(client, organization: id)
     end
 
+    ##
+    # whether this organization still needs to be approved in JD "connections"
+
+    def needs_connection?
+      links.key?('connections')
+    end
+
+    ##
+    # the URI for JD connections page, if available
+
+    def connections_uri
+      record['links'].detect{|link| link['rel'] == 'connections'}&.fetch('uri')
+    end
+
     private
 
     def map_attributes(record)

--- a/lib/my_john_deere_api/version.rb
+++ b/lib/my_john_deere_api/version.rb
@@ -1,3 +1,3 @@
 module MyJohnDeereApi
-  VERSION='3.0.0'
+  VERSION='3.1.0'
 end

--- a/test/lib/my_john_deere_api/model/organization_test.rb
+++ b/test/lib/my_john_deere_api/model/organization_test.rb
@@ -4,6 +4,7 @@ describe 'MyJohnDeereApi::Model::Organization' do
   include JD::LinkHelpers
 
   let(:klass) { JD::Model::Organization }
+  let(:object) { klass.new(client, record) }
 
   let(:record) do
     {
@@ -12,44 +13,54 @@ describe 'MyJohnDeereApi::Model::Organization' do
       "type"=>"customer",
       "member"=>true,
       "id"=>"123456",
-      "links"=>[
-        {"@type"=>"Link", "rel"=>"self", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}"},
-        {"@type"=>"Link", "rel"=>"machines", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/machines"},
-        {"@type"=>"Link", "rel"=>"wdtCapableMachines", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/machines?capability=wdt"},
-        {"@type"=>"Link", "rel"=>"files", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/files"},
-        {"@type"=>"Link", "rel"=>"transferableFiles", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/files?transferable=true"},
-        {"@type"=>"Link", "rel"=>"uploadFile", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/files"},
-        {"@type"=>"Link", "rel"=>"sendFileToMachine", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/fileTransfers"},
-        {"@type"=>"Link", "rel"=>"addMachine", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/machines"},
-        {"@type"=>"Link", "rel"=>"addField", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/fields"},
-        {"@type"=>"Link", "rel"=>"assets", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/assets"},
-        {"@type"=>"Link", "rel"=>"fields", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/fields"},
-        {"@type"=>"Link", "rel"=>"farms", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/farms"},
-        {"@type"=>"Link", "rel"=>"boundaries", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/boundaries"},
-        {"@type"=>"Link", "rel"=>"clients", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/clients"},
-        {"@type"=>"Link", "rel"=>"controllers", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/orgController"}
-      ]
+      "links"=> links,
+    }
+  end
+
+  let(:links) do
+    [
+      {"@type"=>"Link", "rel"=>"self", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}"},
+      {"@type"=>"Link", "rel"=>"machines", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/machines"},
+      {"@type"=>"Link", "rel"=>"wdtCapableMachines", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/machines?capability=wdt"},
+      {"@type"=>"Link", "rel"=>"files", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/files"},
+      {"@type"=>"Link", "rel"=>"transferableFiles", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/files?transferable=true"},
+      {"@type"=>"Link", "rel"=>"uploadFile", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/files"},
+      {"@type"=>"Link", "rel"=>"sendFileToMachine", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/fileTransfers"},
+      {"@type"=>"Link", "rel"=>"addMachine", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/machines"},
+      {"@type"=>"Link", "rel"=>"addField", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/fields"},
+      {"@type"=>"Link", "rel"=>"assets", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/assets"},
+      {"@type"=>"Link", "rel"=>"fields", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/fields"},
+      {"@type"=>"Link", "rel"=>"farms", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/farms"},
+      {"@type"=>"Link", "rel"=>"boundaries", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/boundaries"},
+      {"@type"=>"Link", "rel"=>"clients", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/clients"},
+      {"@type"=>"Link", "rel"=>"controllers", "uri"=>"https://sandboxapi.deere.com/platform/organizations/#{organization_id}/orgController"}
+    ]
+  end
+
+  let(:connections_link) do
+    {
+      "@type"=>"Link",
+      "rel"=>"connections",
+      "uri"=>"https://connections.deere.com/connections/johndeere-0000000000000000000000000000000000000000/organizations"
     }
   end
 
   describe '#initialize(record, client = nil)' do
     it 'sets the attributes from the given record' do
-      organization = klass.new(client, record)
-
-      assert_equal client, organization.client
-      assert_equal accessor, organization.accessor
+      assert_equal client, object.client
+      assert_equal accessor, object.accessor
 
       # basic attributes
-      assert_equal record['name'], organization.name
-      assert_equal record['type'], organization.type
-      assert_equal record['member'], organization.member?
-      assert_equal record['id'], organization.id
+      assert_equal record['name'], object.name
+      assert_equal record['type'], object.type
+      assert_equal record['member'], object.member?
+      assert_equal record['id'], object.id
 
       # links to other things
-      assert_kind_of Hash, organization.links
+      assert_kind_of Hash, object.links
 
       ['fields', 'machines', 'files', 'assets', 'farms', 'boundaries', 'clients', 'controllers'].each do |association|
-        assert_link_for(organization, association)
+        assert_link_for(object, association)
       end
     end
   end
@@ -76,6 +87,42 @@ describe 'MyJohnDeereApi::Model::Organization' do
 
       assets.each do |assets|
         assert_kind_of JD::Model::Asset, assets
+      end
+    end
+  end
+
+  describe '#needs_connection?' do
+    subject { object.needs_connection? }
+
+    describe 'when user needs to connect organization within JD platform' do
+      let(:links) { [connections_link] }
+
+      it 'returns true' do
+        assert subject
+      end
+    end
+
+    describe "when user doesn't need to connect org" do
+      it 'returns false' do
+        refute subject
+      end
+    end
+  end
+
+  describe '#connections_uri' do
+    subject { object.connections_uri }
+
+    describe 'when user needs to connect organization within JD platform' do
+      let(:links) { [connections_link] }
+
+      it 'returns the URI for JD connections' do
+        assert_includes subject, 'https://connections.deere.com/connections'
+      end
+    end
+
+    describe "when user doesn't need to connect org" do
+      it 'returns nil' do
+        assert_nil subject
       end
     end
   end


### PR DESCRIPTION
This PR is mercifully smaller, which is why I expect MORE change requests ;)

In order to support the front-end's JD flow, Periodic Pigeon needs to know:

1. if a given org needs to be connected to R5 on the JD side
2. the link to send the user to make this change

This PR adds a couple methods to the organization model. First, a boolean to determine whether the connection process is needed for a given organization, and also a link to the  JD connections page where the user can authorize the given org.

There's also some new documentation and test refactoring involved.